### PR TITLE
Adapt for vagrant

### DIFF
--- a/tasks/level-1/3.1.1.yml
+++ b/tasks/level-1/3.1.1.yml
@@ -26,12 +26,19 @@
     - scored
 
 - name: 3.1.1 - Ensure IP forwarding is disabled in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.ip_forward=0"
-    - "sysctl -w net.ipv6.conf.all.forwarding=0"
-    - "sysctl -w net.ipv4.route.flush=1"
-    - "sysctl -w net.ipv6.route.flush=1"
+    - name: "net.ipv4.ip_forward"
+      value: 0
+    - name: "net.ipv6.conf.all.forwarding"
+      value: 0
+    - name: "net.ipv4.route.flush"
+      value: 1
+    - name: "net.ipv6.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.1.2.yml
+++ b/tasks/level-1/3.1.2.yml
@@ -26,11 +26,17 @@
     - scored
 
 - name: 3.1.2 - Ensure packet redirect sending is disabled in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.send_redirects=0"
-    - "sysctl -w net.ipv4.conf.default.send_redirects=0"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.conf.all.send_redirects"
+      value: 0
+    - name: "net.ipv4.conf.default.send_redirects"
+      value: 0
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.1.yml
+++ b/tasks/level-1/3.2.1.yml
@@ -47,14 +47,23 @@
     - scored
 
 - name: 3.2.1 - Ensure source routed packets are not accepted in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.accept_source_route=0"
-    - "sysctl -w net.ipv4.conf.default.accept_source_route=0"
-    - "sysctl -w net.ipv6.conf.all.accept_source_route=0"
-    - "sysctl -w net.ipv6.conf.default.accept_source_route=0"
-    - "sysctl -w net.ipv4.route.flush=1"
-    - "sysctl -w net.ipv6.route.flush=1"
+    - name: "net.ipv4.conf.all.accept_source_route"
+      value: 0
+    - name: "net.ipv4.conf.default.accept_source_route"
+      value: 0
+    - name: "net.ipv6.conf.all.accept_source_route"
+      value: 0
+    - name: "net.ipv6.conf.default.accept_source_route"
+      value: 0
+    - name: "net.ipv4.route.flush"
+      value: 1
+    - name: "net.ipv6.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.2.yml
+++ b/tasks/level-1/3.2.2.yml
@@ -47,14 +47,23 @@
     - scored
 
 - name: 3.2.2 - Ensure ICMP redirects are not accepted in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.accept_redirects=0"
-    - "sysctl -w net.ipv4.conf.default.accept_redirects=0"
-    - "sysctl -w net.ipv6.conf.all.accept_redirects=0"
-    - "sysctl -w net.ipv6.conf.default.accept_redirects=0"
-    - "sysctl -w net.ipv4.route.flush=1"
-    - "sysctl -w net.ipv6.route.flush=1"
+    - name: "net.ipv4.conf.all.accept_redirects"
+      value: 0
+    - name: "net.ipv4.conf.default.accept_redirects"
+      value: 0
+    - name: "net.ipv6.conf.all.accept_redirects"
+      value: 0
+    - name: "net.ipv6.conf.default.accept_redirects"
+      value: 0
+    - name: "net.ipv4.route.flush"
+      value: 1
+    - name: "net.ipv6.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.3.yml
+++ b/tasks/level-1/3.2.3.yml
@@ -26,11 +26,17 @@
     - scored
 
 - name: 3.2.3 - Ensure secure ICMP redirects are not accepted in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.secure_redirects=0"
-    - "sysctl -w net.ipv4.conf.default.secure_redirects=0"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.conf.all.secure_redirects"
+      value: 0
+    - name: "net.ipv4.conf.default.secure_redirects"
+      value: 0
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.4.yml
+++ b/tasks/level-1/3.2.4.yml
@@ -26,11 +26,17 @@
     - scored
 
 - name: 3.2.4 - Ensure suspicious packets are logged in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.log_martians=1"
-    - "sysctl -w net.ipv4.conf.default.log_martians=1"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.conf.all.log_martians"
+      value: 1
+    - name: "net.ipv4.conf.default.log_martians"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.5.yml
+++ b/tasks/level-1/3.2.5.yml
@@ -15,10 +15,15 @@
     - scored
 
 - name: 3.2.5 - Ensure broadcast ICMP requests are ignored in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.icmp_echo_ignore_broadcasts"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.6.yml
+++ b/tasks/level-1/3.2.6.yml
@@ -15,10 +15,15 @@
     - scored
 
 - name: 3.2.6 - Ensure bogus ICMP responses are ignored in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.icmp_ignore_bogus_error_responses"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.7.yml
+++ b/tasks/level-1/3.2.7.yml
@@ -26,11 +26,17 @@
     - scored
 
 - name: 3.2.7 - Ensure Reverse Path Filtering is enabledin active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.conf.all.rp_filter=1"
-    - "sysctl -w net.ipv4.conf.default.rp_filter=1"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.conf.all.rp_filter"
+      value: 1
+    - name: "net.ipv4.conf.default.rp_filter"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.8.yml
+++ b/tasks/level-1/3.2.8.yml
@@ -16,10 +16,15 @@
 
 
 - name: 3.2.8 - Ensure TCP SYN Cookies is enabledin active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv4.tcp_syncookies=1"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv4.tcp_syncookies"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/3.2.9.yml
+++ b/tasks/level-1/3.2.9.yml
@@ -27,11 +27,17 @@
 
 
 - name: 3.2.9 - Ensure IPv6 router advertisements are not accepted in active kernel parameters
-  command: "{{ item }}"
+  sysctl:
+    name: "{{ item.name }}"
+    sysctl_set: yes
+    value: "{{ item.value }}"
   with_items:
-    - "sysctl -w net.ipv6.conf.all.accept_ra=0"
-    - "sysctl -w net.ipv6.conf.default.accept_ra=0"
-    - "sysctl -w net.ipv4.route.flush=1"
+    - name: "net.ipv6.conf.all.accept_ra"
+      value: 1
+    - name: "net.ipv6.conf.default.accept_ra"
+      value: 1
+    - name: "net.ipv4.route.flush"
+      value: 1
   tags:
     - level-1
     - section-3

--- a/tasks/level-1/5.4.2.yml
+++ b/tasks/level-1/5.4.2.yml
@@ -15,9 +15,11 @@
     - scored
 
 - name: 5.4.2 - Lock system user passwords
-  command: "usermod -L {{ item }}"
+  user:
+    name: "{{ item }}"
+    password_lock: yes
   with_items: "{{ audit_5_4_2.stdout_lines }}"
-  when: item != "root"
+  when: "item != 'root'"
   tags:
     - level-1
     - section-5


### PR DESCRIPTION
When running this against my vagrant image ([bento/amazon-linux-2](https://github.com/chef/bento/blob/master/packer_templates/amazonlinux/amazon-2-x86_64.json)) the `command` module kept failing with the message `No such file or directory`. I tried using one of the dedicated modules and this didn't happen. 😄 

There shouldn't be any substantive changes (if there are that's an error on my part) just switching from using `command` to using a module (`sysctl` or `user`)